### PR TITLE
migration : add enabledByDefault in VolunteerRole

### DIFF
--- a/packages/api-core/src/groups/entities/volunteer-role.entity.ts
+++ b/packages/api-core/src/groups/entities/volunteer-role.entity.ts
@@ -1,11 +1,11 @@
 import {
-  Column,
-  Entity,
-  Index,
-  JoinColumn,
-  ManyToOne,
-  OneToMany,
-  PrimaryGeneratedColumn,
+	Column,
+	Entity,
+	Index,
+	JoinColumn,
+	ManyToOne,
+	OneToMany,
+	PrimaryGeneratedColumn,
 } from 'typeorm';
 import { CatalogEntity } from '../../vendors/entities/catalog.entity';
 import { GroupEntity } from './group.entity';
@@ -20,6 +20,10 @@ export class VolunteerRoleEntity {
 
   @Column('varchar', { name: 'name', length: 64 })
   name: string;
+
+	// field enabledByDefault is added (bool), true by default
+	@Column('tinyint', { name: 'enabledByDefault', width:1, default: 1 })
+	enabledByDefault: boolean;
 
   @Column('int', { name: 'groupId' })
   groupId: number;

--- a/packages/api-core/src/migrations/1716900422752-role-group-enabled-by-default.ts
+++ b/packages/api-core/src/migrations/1716900422752-role-group-enabled-by-default.ts
@@ -1,0 +1,14 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class roleGroupEnabledByDefault1716900422752 implements MigrationInterface {
+    name = 'roleGroupEnabledByDefault1716900422752'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE \`VolunteerRole\` ADD \`enabledByDefault\` tinyint(1) NOT NULL DEFAULT '1'`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE \`VolunteerRole\` DROP COLUMN \`enabledByDefault\``);
+    }
+
+}


### PR DESCRIPTION
Migration pour la PR https://github.com/CAMAP-APP/camap-hx/pull/26

Ajout du champ `enabledByDefault `dans `VolunteerRole `(concerne les rôles globaux par groupe)