### PR TITLE
Add realtime stock prediction in orders and defaultOrders

### DIFF
--- a/packages/front-core/src/lib/REST/useRestGetApi.tsx
+++ b/packages/front-core/src/lib/REST/useRestGetApi.tsx
@@ -21,6 +21,9 @@ const useRestGetApi = <T extends {}>(
       ...options,
       method: 'GET',
       credentials: 'include',
+      headers:{
+        'Accept': 'application/json'
+      }
     })
       .then(async (response) => {
         if (response.ok) {

--- a/packages/front-core/src/lib/REST/useRestLazyGetApi.tsx
+++ b/packages/front-core/src/lib/REST/useRestLazyGetApi.tsx
@@ -19,6 +19,9 @@ const useRestLazyGet = <T extends {}>(
         ...options,
         method: 'GET',
         credentials: 'include',
+        headers:{
+          'Accept': 'application/json'
+        }
       })
         .then(async (response) => {
           if (response.ok) {

--- a/packages/front-core/src/lib/REST/useRestPostApi.tsx
+++ b/packages/front-core/src/lib/REST/useRestPostApi.tsx
@@ -19,6 +19,9 @@ const useRestPostApi = <TResult extends {}, TBody extends {}>(
         method: 'POST',
         body: JSON.stringify(body),
         credentials: 'include',
+        headers:{
+          'Accept': 'application/json'
+        }
       })
         .then(async (response) => {
           if (response.ok) {

--- a/packages/front-core/src/modules/csaCatalog/CsaCatalogRouter.tsx
+++ b/packages/front-core/src/modules/csaCatalog/CsaCatalogRouter.tsx
@@ -134,7 +134,7 @@ const CsaCatalogRouter = ({ userId }: CsaCatalogRouterProps) => {
   };
 
   const onAbsencesNext = async () => {
-    const subscriptionData = await createSubscription({
+    const subscriptionSucceeded = await createSubscription({
       userId,
       catalogId,
       defaultOrder: Object.keys(defaultOrder).map((productId) => ({
@@ -144,7 +144,7 @@ const CsaCatalogRouter = ({ userId }: CsaCatalogRouterProps) => {
       absentDistribIds: absenceDistributionsIds as number[] | null,
     });
 
-    if (!subscriptionData) return;
+    if (!subscriptionSucceeded) return;
     window.scrollTo({ top: 0, behavior: 'smooth' });
 
     setShowPresentation(false);

--- a/packages/front-core/src/modules/csaCatalog/interfaces.ts
+++ b/packages/front-core/src/modules/csaCatalog/interfaces.ts
@@ -30,8 +30,9 @@ export type RestCsaCatalog = Pick<
   absentDistribsMaxNb?: number;
   distribMinOrdersTotal: number;
   hasStockManagement: boolean;
-  stocksPerProductDistribution: { [productId: number]: { [distribId: number]: number } };
 };
+
+export type RestStocksPerProductDistribution = { [productId: number]: { [distribId: number]: number } };
 
 export type RestCsaCatalogAbsences = {
   startDate: string;

--- a/packages/front-core/src/modules/csaCatalog/requests.tsx
+++ b/packages/front-core/src/modules/csaCatalog/requests.tsx
@@ -8,7 +8,7 @@ import {
   RestCsaDefaultOrder,
   RestCsaDefaultOrderWithPrice,
   RestCsaSubscription,
-  RestCsaSubscriptionAbsences,
+  RestCsaSubscriptionAbsences, RestStocksPerProductDistribution,
 } from './interfaces';
 
 /*
@@ -22,6 +22,19 @@ export const useRestCatalogGet = (catalogId: number) => {
     [catalogId],
   );
   return useRestGetApi<RestCsaCatalog>(url);
+};
+
+/*
+ * Get catalog infos
+ */
+
+export const useRestStocksGet = (catalogId: number) => {
+  const url = React.useMemo(
+    () => `/catalog/stocksPerProductDistribution/${catalogId}`,
+
+    [catalogId],
+  );
+  return useRestLazyGet<RestStocksPerProductDistribution>(url);
 };
 
 /*


### PR DESCRIPTION
Essayer de prédire instantanément l'évolution du stock en fonction des données fournies par l'utilisateur (globales ou par distribution, + gestion des absences).

PR lié (ajout d'une route dans l'API haxe): https://github.com/CAMAP-APP/camap-hx/pull/47

## Comportement
- Le stock global est désormais affiché en en-tête de ligne
- La valeur de stock est mise à jour immédiatement lorsqu'une valeur de commande est modifiée
- Pour chaque unité de commande ajoutée, 1 unité de stock est décrémentée
- Exception: Pour la commande par défaut si stock global, 1 unité est décrémenté pour chaque distribution restante (ignore les distribs passées, règle=Date début distrib > aujourd'hui). 
    - Dans l'exemple ci-dessous lorsque la commande est augmentée de 1 le stock est décrémenté du nombre de distrib (4).
- Le calcul du stock global pour la commande "par défaut" prends le pire scénario (aucune absence). Selon le nombre d'absences le stock réel pourra différer de la prédiction affichée.
- Dans le cas d'une modification de commande existante le nombre d'absences est connu et prise en compte dans la prédiction sur une modification de commande ou de commande par défaut.

## Aperçu
![image](https://github.com/CAMAP-APP/camap-ts/assets/722132/df07aad3-e846-420a-a6d5-e753393ccb18)

![image](https://github.com/CAMAP-APP/camap-ts/assets/722132/29cf43e0-deb9-4d46-8477-9a145ccdf4dd)
