### PR TITLE
feat(login): afficher/masquer le mot de passe sur les formulaires de …

### DIFF
--- a/packages/front-core/src/modules/loginRegistration/LoginBox.tsx
+++ b/packages/front-core/src/modules/loginRegistration/LoginBox.tsx
@@ -1,6 +1,7 @@
 import SimpleField from '@components/utils/SimpleField';
+import { Visibility, VisibilityOff } from '@mui/icons-material';
 import { LoadingButton } from '@mui/lab';
-import { Box, Container } from '@mui/material';
+import { Box, Container, IconButton, InputAdornment } from '@mui/material';
 import { loginSchema } from 'camap-common';
 import { Form, Formik, FormikHelpers } from 'formik';
 import React from 'react';
@@ -35,6 +36,7 @@ const LoginBox = ({
   const [recordBadLoginMutation] = useRecordBadLoginMutation();
 
   const [error, setError] = React.useState<string>();
+  const [showPassword, setShowPassword] = React.useState(false);
 
   async function submit(
     values: LoginBoxFormValues,
@@ -93,7 +95,20 @@ const LoginBox = ({
               name="password"
               label={t('password')}
               disabled={isSubmitting}
-              type="password"
+              type={showPassword ? 'text' : 'password'}
+              InputProps={{
+                endAdornment: (
+                  <InputAdornment position="end">
+                    <IconButton
+                      aria-label={showPassword ? t('hidePassword') : t('showPassword')}
+                      onClick={() => setShowPassword((prev) => !prev)}
+                      edge="end"
+                    >
+                      {showPassword ? <VisibilityOff /> : <Visibility />}
+                    </IconButton>
+                  </InputAdornment>
+                ),
+              }}
             />
             <Box pt={2} pb={2}>
               <LoadingButton

--- a/packages/front-core/src/modules/loginRegistration/RegistrationBox.tsx
+++ b/packages/front-core/src/modules/loginRegistration/RegistrationBox.tsx
@@ -1,7 +1,7 @@
 import SimpleField from '@components/utils/SimpleField';
-import { ChevronRight } from '@mui/icons-material';
+import { ChevronRight, Visibility, VisibilityOff } from '@mui/icons-material';
 import { LoadingButton } from '@mui/lab';
-import { Box, Container } from '@mui/material';
+import { Box, Container, IconButton, InputAdornment } from '@mui/material';
 import {
   addressSchema,
   addressSchemaNotRequired,
@@ -79,6 +79,7 @@ const RegistrationBox = ({
   const invitedUser = data?.getInvitedUserToRegister;
 
   const [error, setError] = React.useState<string>();
+  const [showPassword, setShowPassword] = React.useState(false);
 
   React.useEffect(() => {
     if (!unexpectedError) return;
@@ -313,14 +314,40 @@ const RegistrationBox = ({
                 name="password"
                 label={t('password')}
                 disabled={isSubmitting}
-                type="password"
+                type={showPassword ? 'text' : 'password'}
                 helperText={t('min8Char')}
+                InputProps={{
+                  endAdornment: (
+                    <InputAdornment position="end">
+                      <IconButton
+                        aria-label={showPassword ? t('hidePassword') : t('showPassword')}
+                        onClick={() => setShowPassword((prev) => !prev)}
+                        edge="end"
+                      >
+                        {showPassword ? <VisibilityOff /> : <Visibility />}
+                      </IconButton>
+                    </InputAdornment>
+                  ),
+                }}
               />
               <SimpleField
                 name="confirmPassword"
                 label={t('confirmPassword')}
                 disabled={isSubmitting}
-                type="password"
+                type={showPassword ? 'text' : 'password'}
+                InputProps={{
+                  endAdornment: (
+                    <InputAdornment position="end">
+                      <IconButton
+                        aria-label={showPassword ? t('hidePassword') : t('showPassword')}
+                        onClick={() => setShowPassword((prev) => !prev)}
+                        edge="end"
+                      >
+                        {showPassword ? <VisibilityOff /> : <Visibility />}
+                      </IconButton>
+                    </InputAdornment>
+                  ),
+                }}
               />
               <Box pt={1} textAlign="center">
                 <Field

--- a/public/locales/fr/login-registration.json
+++ b/public/locales/fr/login-registration.json
@@ -16,6 +16,8 @@
   "invalidPassword": "Votre mot de passe doit contenir au moins 8 caractères",
   "min8Char": "Minimum 8 caractères",
   "confirmPassword": "Confirmez votre mot de passe",
+  "showPassword": "Afficher le mot de passe",
+  "hidePassword": "Masquer le mot de passe",
   "loginAs": "Connexion en cours...",
   "emailAlreadyRegistered": "Email déjà utiilisé, connectez-vous ci-dessous."
 }


### PR DESCRIPTION
…connexion et d'inscription

Ajout d'un bouton œil (toggle) sur les champs mot de passe des formulaires LoginBox et RegistrationBox. Sur l'inscription, un seul toggle contrôle les deux champs password et confirmPassword simultanément.

Closes Mantis #325