### PR TITLE
mantis-181 : ajouter "Vous pouvez répondre à" en pied de mail

### DIFF
--- a/packages/api-core/mails/src/_layout-group.twig
+++ b/packages/api-core/mails/src/_layout-group.twig
@@ -45,4 +45,7 @@
 		Pour vous désabonner,
 		<a href={{ "#{quitGroupLink}" }} rel="notrack">quittez ce groupe</a>
 		si vous ne souhaitez plus recevoir de messages</p>
+	{% if replyTo is defined and replyTo %}
+	<p>Vous pouvez répondre à : <a href={{ "mailto:#{replyTo}" }}>{{ replyTo }}</a></p>
+	{% endif %}
 {% endblock %}

--- a/packages/api-core/src/mails/mails.service.ts
+++ b/packages/api-core/src/mails/mails.service.ts
@@ -101,6 +101,9 @@ export class MailsService {
     try {
       const theme = await this.variableService.getTheme();
       templateParameters.theme = theme;
+      if (replyToSenderHeader && sender) {
+        templateParameters.replyTo = sender.email;
+      }
       const templatedHtml = await this.renderTwing(templateName, templateParameters);
 
       const sanitizedRecipients = (recipients ?? []).filter((r) =>


### PR DESCRIPTION
Injecte l'adresse Reply-To dans les paramètres du template lors de la création d'un BufferedJsonMail avec replyToSenderHeader=true, et l'affiche conditionnellement dans le footer du layout-group (emails de messagerie).