### PR TITLE
[mantis-330/331] Refonte de la désinscription de permanence

### DIFF
--- a/packages/front-core/src/modules/volunteersCalendar/VolunteersCalendar.module.tsx
+++ b/packages/front-core/src/modules/volunteersCalendar/VolunteersCalendar.module.tsx
@@ -269,6 +269,14 @@ const VolunteersCalendar = ({
     [multiDistribs, firstDistributionIndex, maxNbDistribToShow],
   );
 
+  const handleUnsubscribeSuccess = React.useCallback(() => {
+    setMultiDistribs([]);
+    setRoles([]);
+    didGetNextDistributionIndexOnce.current = false;
+    const now = new Date();
+    doGetVolunteerMultiDistribs(subMonths(now, 4), addMonths(now, 4));
+  }, [doGetVolunteerMultiDistribs]);
+
   const onBackClick = () => {
     goTo('/');
   };
@@ -454,13 +462,11 @@ const VolunteersCalendar = ({
                               multiDistrib={d}
                               userId={userId}
                               roleId={r.id}
+                              roleName={r.name}
                               daysBeforeDutyPeriodsOpen={
                                 daysBeforeDutyPeriodsOpen
                               }
-                              returnUrl={`/distribution/volunteersCalendar${focusedMultiDistribId
-                                  ? `/${focusedMultiDistribId}`
-                                  : ''
-                                }`}
+                              onUnsubscribeSuccess={handleUnsubscribeSuccess}
                             />
                           </Box>
                         ))}

--- a/packages/front-core/src/modules/volunteersCalendar/components/VolunteersCalendarDistributionRole.tsx
+++ b/packages/front-core/src/modules/volunteersCalendar/components/VolunteersCalendarDistributionRole.tsx
@@ -1,43 +1,51 @@
 import {
+  Alert,
   Box,
   Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
   SxProps,
   Theme,
   Tooltip,
   Typography,
 } from '@mui/material';
+import React from 'react';
 import { useCamapTranslation } from '../../../utils/hooks/use-camap-translation';
-import { RestCsaMultiDistribWithVolunteerRoles } from '../requests';
+import { RestCsaMultiDistribWithVolunteerRoles, useRestUnsubscribeFromRole } from '../requests';
 
 interface VolunteersCalendarDistributionRoleProps {
   multiDistrib: RestCsaMultiDistribWithVolunteerRoles;
   userId: number;
   roleId: number;
+  roleName: string;
   daysBeforeDutyPeriodsOpen: number;
-  returnUrl: string;
+  onUnsubscribeSuccess: () => void;
 }
 
 const VolunteersCalendarDistributionRole = ({
   multiDistrib,
   userId,
   roleId,
+  roleName,
   daysBeforeDutyPeriodsOpen,
-  returnUrl,
+  onUnsubscribeSuccess,
 }: VolunteersCalendarDistributionRoleProps) => {
   const { t } = useCamapTranslation({
     t: 'volunteers-calendar',
   });
 
-  const from = new Date();
-  const to = new Date();
+  const [dialogOpen, setDialogOpen] = React.useState(false);
+  const [loading, setLoading] = React.useState(false);
+  const [unsubscribe, { error }] = useRestUnsubscribeFromRole(multiDistrib.id, roleId);
 
   const roleKey = String(roleId);
   const hasVolunteerRole = !!multiDistrib.hasVolunteerRole?.[roleKey];
-  const volunteerForRole = hasVolunteerRole
-  ? (multiDistrib.volunteerForRole?.[roleKey] ?? null)
-  : null;
-
-  const volunteer = volunteerForRole;
+  const volunteer = hasVolunteerRole
+    ? (multiDistrib.volunteerForRole?.[roleKey] ?? null)
+    : null;
 
   let sxColors: SxProps<Theme> = {
     bgcolor: 'initial',
@@ -49,6 +57,25 @@ const VolunteersCalendarDistributionRole = ({
       color: (theme: Theme) => theme.palette.action.disabled,
     };
   }
+
+  const distribDate = new Intl.DateTimeFormat('fr-FR', {
+    weekday: 'long',
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(new Date(multiDistrib.distribStartDate));
+
+  const handleConfirm = async () => {
+    setLoading(true);
+    const success = await unsubscribe({} as Record<string, never>);
+    setLoading(false);
+    if (success) {
+      setDialogOpen(false);
+      onUnsubscribeSuccess();
+    }
+  };
 
   return (
     <Box
@@ -77,7 +104,7 @@ const VolunteersCalendarDistributionRole = ({
                 <Button
                   variant="contained"
                   color="error"
-                  href={`/distribution/unsubscribeFromRole/${multiDistrib.id}/${roleId}?returnUrl=${returnUrl}&from=${from}&to${to}`}
+                  onClick={() => setDialogOpen(true)}
                 >
                   {t('unsubscribe')}
                 </Button>
@@ -87,7 +114,7 @@ const VolunteersCalendarDistributionRole = ({
           {!volunteer && multiDistrib.canVolunteersJoin && (
             <Button
               variant="contained"
-              href={`/distribution/volunteersCalendar?returnUrl=${returnUrl}&distrib=${multiDistrib.id}&role=${roleId}&from=${from}&to=${to}`}
+              href={`/distribution/volunteersCalendar?distrib=${multiDistrib.id}&role=${roleId}`}
             >
               {t('join')}
             </Button>
@@ -109,6 +136,35 @@ const VolunteersCalendarDistributionRole = ({
           <Box position={'absolute'} top={0} left={0} right={0} bottom={0} />
         </Tooltip>
       )}
+
+      <Dialog open={dialogOpen} onClose={() => setDialogOpen(false)}>
+        <DialogTitle>
+          {t('unsubscribeDialogTitle', { roleName, distribDate })}
+        </DialogTitle>
+        <DialogContent>
+          {error && (
+            <Alert severity="error" sx={{ mb: 2 }}>
+              {error}
+            </Alert>
+          )}
+          <DialogContentText>
+            {t('unsubscribeDialogMessage')}
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setDialogOpen(false)} disabled={loading}>
+            {t('cancel')}
+          </Button>
+          <Button
+            variant="contained"
+            color="error"
+            onClick={handleConfirm}
+            disabled={loading}
+          >
+            {t('yes')}
+          </Button>
+        </DialogActions>
+      </Dialog>
     </Box>
   );
 };

--- a/packages/front-core/src/modules/volunteersCalendar/requests.tsx
+++ b/packages/front-core/src/modules/volunteersCalendar/requests.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { MultiDistrib } from '../../gql';
 import useRestLazyGet from '../../lib/REST/useRestLazyGetApi';
+import useRestPostApi from '../../lib/REST/useRestPostApi';
 
 type Volunteer = {
   id: number;
@@ -30,4 +31,12 @@ export const useRestVolunteerMultiDistribsLazyGet = () => {
     multiDistribs: RestCsaMultiDistribWithVolunteerRoles[];
     roles: RestCsaVolunteerRoles[];
   }>(url);
+};
+
+export const useRestUnsubscribeFromRole = (distribId: number, roleId: number) => {
+  const url = React.useMemo(
+    () => `/distributions/unsubscribeFromRole/${distribId}/${roleId}`,
+    [distribId, roleId],
+  );
+  return useRestPostApi<{ success: boolean }, Record<string, never>>(url);
 };

--- a/public/locales/fr/volunteers-calendar.json
+++ b/public/locales/fr/volunteers-calendar.json
@@ -16,5 +16,9 @@
   "dutyToDo": "permanence à faire.",
   "dutyToDo_plural": "permanences à faire.",
   "thereIsNoDistributionOnThisPeriod": "Il n'y a pas de distributions sur cette période",
-  "defineGroupRoles": "Définir les rôles du groupe"
+  "defineGroupRoles": "Définir les rôles du groupe",
+  "unsubscribeDialogTitle": "Permanence {{roleName}} du {{distribDate}}",
+  "unsubscribeDialogMessage": "Êtes-vous sûr de vouloir vous désister ?",
+  "yes": "Oui",
+  "cancel": "Annuler"
 }


### PR DESCRIPTION
## Contexte

Deux problèmes liés sur le flux de désinscription d'un bénévole à une permanence :

- **mantis-330** : la page `/distribution/unsubscribeFromRole` imposait la saisie
  d'un motif envoyé à tous les membres du groupe, créant une friction inutile.
- **mantis-331** : le mail de désinscription était envoyé systématiquement, même
  quand le rappel des rôles vacants (cron) n'avait pas encore été déclenché —
  rendant la notification redondante et prématurée.

## Solution

### camap-hx

**`controller/Distribution.hx`**
- `doUnsubscribeFromRole` redirige vers `/distribution/volunteersCalendar`
  (URL legacy conservée pour compatibilité).

**`controller/api/Distributions.hx`**
- Nouvel endpoint `POST /api/distributions/unsubscribeFromRole/{distribId}/{roleId}` :
  effectue la désinscription sans motif requis.

**`service/VolunteerService.hx`**
- `removeUserFromRole` : suppression du paramètre `reason`.
- Nouvelle condition d'envoi du mail : uniquement si `now > alertDate`
  (c.-à-d. après la date à laquelle le cron « rôles vacants » se déclenche).
  Avant cette date, pas d'envoi — le cron prendra le relais.
- Simplification : un seul jeu de destinataires (tous les membres).

**`lang/master/tpl/mail/volunteerUnsuscribed.mtt`**
- Suppression du paragraphe « a indiqué la raison suivante ».
- Nouveau libellé : « **[Nom]** s'est désisté(e) du rôle **[Rôle]**. »

### camap-ts

**`modules/volunteersCalendar/requests.tsx`**
- Hook `useRestUnsubscribeFromRole` (appel REST POST).

**`modules/volunteersCalendar/components/VolunteersCalendarDistributionRole.tsx`**
- Le bouton « Se désinscrire » ouvre une Dialog MUI de confirmation
  (titre : « Permanence [rôle] du [date] », boutons Oui / Annuler)
  au lieu de naviguer vers la page Haxe supprimée.

**`modules/volunteersCalendar/VolunteersCalendar.module.tsx`**
- Passage de `roleName` et d'un callback `onUnsubscribeSuccess`
  (reset état + re-fetch du calendrier).

**`public/locales/fr/volunteers-calendar.json`**
- Clés de traduction pour la Dialog (`unsubscribeDialogTitle`,
  `unsubscribeDialogMessage`, `yes`, `cancel`).

## Comment tester

1. Se connecter en tant que bénévole inscrit à une permanence.
2. Ouvrir `/distribution/volunteersCalendar`.
3. Cliquer « Se désinscrire » → vérifier l'affichage de la Dialog avec le bon rôle et la bonne date.
4. « Annuler » → la Dialog se ferme, rien ne change.
5. « Oui » → désinscription effectuée, calendrier rafraîchi.
6. Accéder à `/distribution/unsubscribeFromRole/{id}/{id}` → redirection vers le calendrier.

**Mail — cas 1 (désinscription avant la date d'alerte)**
- Permanence dans 10 jours, `vacantVolunteerRolesMailDaysBeforeDutyPeriod = 7`
- Se désinscrire → aucun mail envoyé.

**Mail — cas 2 (désinscription après la date d'alerte)**
- Permanence dans 5 jours → mail envoyé à tous les membres, sans mention de raison.

Co-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>